### PR TITLE
Preview 컴포넌트 구현

### DIFF
--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -1,5 +1,71 @@
-function Preview() {
-  return <div className="w-full border-solid border-2 border-indigo-600">Preview</div>;
+import { ChangeEvent, useEffect, useState } from 'react';
+
+export default function Preview() {
+  const [previewRatio, setPreviewRatio] = useState(PREVIEWRATIOOPTIONS[INITIALRATIO]);
+  const [previewWidth, setPreviewWidth] = useState<number>(INITIALHEIGHT);
+
+  const calculatePreviewWidth = (ratio: number) => {
+    const preview = document.querySelector('#preview') as HTMLDivElement;
+    return preview.clientHeight * ratio;
+  };
+
+  const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const key = event.target.value as keyof PreviewRatioOptionsType;
+    setPreviewRatio(PREVIEWRATIOOPTIONS[key]);
+  };
+
+  useEffect(() => {
+    setPreviewWidth(calculatePreviewWidth(previewRatio));
+  }, [previewRatio]);
+
+  return (
+    <>
+      <div id="preview" className="w-full h-[188px] tablet:h-[300px] flex justify-center items-center">
+        <div
+          style={{
+            width: `${previewWidth}px`,
+            height: '100%',
+            backgroundImage: `url(${DEMOPICTURE})`,
+            backgroundSize: 'auto 100%',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'center',
+          }}
+        ></div>
+      </div>
+      <div className="w-full my-[10px]">
+        <div className="mb-[10px] font-bold">레이아웃</div>
+        <select
+          className="w-full h-[44px] text-center rounded-[8px] appearance-none focus:outline-0"
+          style={{ background: `url(${ARROW}) no-repeat right 24px center`, border: '1px solid #1B1B1C' }}
+          onChange={handleSelectChange}
+        >
+          {Object.keys(PREVIEWRATIOOPTIONS).map((key) => (
+            <option key={key} value={key}>
+              {key} 썸네일
+            </option>
+          ))}
+        </select>
+      </div>
+    </>
+  );
 }
 
-export default Preview;
+interface PreviewRatioOptionsType {
+  '1 : 1': number;
+  '4 : 3': number;
+  '16 : 9': number;
+}
+
+const INITIALRATIO = '1 : 1';
+const INITIALHEIGHT = 188;
+const PREVIEWRATIOOPTIONS: PreviewRatioOptionsType = {
+  '1 : 1': 1,
+  '4 : 3': 4 / 3,
+  '16 : 9': 16 / 9,
+};
+
+const DEMOPICTURE =
+  'https://s3.us-west-2.amazonaws.com/secure.notion-static.com/00e7a483-4bef-4505-b81b-599c1955b0cc/1.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20230226%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230226T045054Z&X-Amz-Expires=86400&X-Amz-Signature=08e7eb2e267581bae7216db112629951ff332f4894e2f6597b290c9aef48e9af&X-Amz-SignedHeaders=host&response-content-disposition=filename%3D%221.jpg%22&x-id=GetObject';
+
+const ARROW =
+  'https://s3.us-west-2.amazonaws.com/secure.notion-static.com/187b79b9-e5ca-494e-9d75-fe8722eaa6f7/Vector.svg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20230225%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230225T172543Z&X-Amz-Expires=86400&X-Amz-Signature=158198f4f90d7b0ceea159a194abadcff38c23849c6fbff3f999d3eb7af18524&X-Amz-SignedHeaders=host&response-content-disposition=filename%3D%22Vector.svg%22&x-id=GetObject';

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -50,6 +50,10 @@ module.exports = {
         xsm: '12px',
       },
     },
+    screens: {
+      desktop: '1024px',
+      tablet: '764px',
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
### ✅ PR 타입

- [x] Feature
- [ ] Bug Fix

### 📝 개요
Preview 컴포넌트를 구현하였습니다.

### 💽 작업 사항
- select에서 선택한 옵션에 따라 Preview의 크기를 계산하여 설정하도록 하였습니다.
- 모바일 화면일때와 테블릿 이상의 화면일때 Preview의 크기를 변경되도록 하였습니다.
   - 임의로 크기를 조절하는 경우 바로 적용되지 않습니다. resize이벤트와 함께 구현되어야하는데 디바운싱도 같이 구현되어야할 필요성이 있지만 현재 스프린트에서 필수로 진행되어야할 부분은 아니라고 판단하였고 피그잼의 backlog에 작성해두었습니다.

### 🖼 결과
<img width="1322" alt="데스크톱 Preview 화면" src="https://user-images.githubusercontent.com/75886763/221393266-7913a007-1912-41fa-bc21-7cad25f0126f.png">
<img width="345" alt="모바일 Preview 화면" src="https://user-images.githubusercontent.com/75886763/221393282-0bfb1442-89b2-4068-aa36-5f24714805cd.png">
