### PR TITLE
Preview컴포넌트의 useState로 인한 불필요한 렌더링 억제

### DIFF
--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -1,27 +1,30 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 export default function Preview() {
-  const [previewRatio, setPreviewRatio] = useState(PREVIEWRATIOOPTIONS[INITIALRATIO]);
-  const [previewWidth, setPreviewWidth] = useState<number>(INITIALHEIGHT);
+  const preview = useRef<HTMLDivElement>(null);
+  const previewRatio = useRef(PREVIEWRATIOOPTIONS[INITIALRATIO]);
+  const [previewWidth, setPreviewWidth] = useState<number>(
+    window.innerWidth >= 764 ? INITIALHEIGHT.table : INITIALHEIGHT.mobile,
+  );
 
   const calculatePreviewWidth = (ratio: number) => {
-    const preview = document.querySelector('#preview') as HTMLDivElement;
-    return preview.clientHeight * ratio;
+    if (preview && preview.current) {
+      return preview.current.clientHeight * ratio;
+    }
+    return previewWidth;
   };
 
   const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const key = event.target.value as keyof PreviewRatioOptionsType;
-    setPreviewRatio(PREVIEWRATIOOPTIONS[key]);
+    previewRatio.current = PREVIEWRATIOOPTIONS[key];
+    setPreviewWidth(calculatePreviewWidth(previewRatio.current));
   };
-
-  useEffect(() => {
-    setPreviewWidth(calculatePreviewWidth(previewRatio));
-  }, [previewRatio]);
 
   return (
     <>
-      <div id="preview" className="w-full h-[188px] tablet:h-[300px] flex justify-center items-center">
+      <div className="w-full h-[188px] tablet:h-[300px] flex justify-center items-center">
         <div
+          ref={preview}
           style={{
             width: `${previewWidth}px`,
             height: '100%',
@@ -57,7 +60,7 @@ interface PreviewRatioOptionsType {
 }
 
 const INITIALRATIO = '1 : 1';
-const INITIALHEIGHT = 188;
+const INITIALHEIGHT = { mobile: 188, table: 300 };
 const PREVIEWRATIOOPTIONS: PreviewRatioOptionsType = {
   '1 : 1': 1,
   '4 : 3': 4 / 3,


### PR DESCRIPTION
### ✅ PR 타입

- [ ] Feature
- [x] refactoring

### 📝 개요
Preview 컴포넌트에서 useState로 인한 불필요한 렌더링을 억제하였습니다.

### 💽 작업 사항
- Preview 컴포넌트에서 렌더링과 관련없는 useState를 useRef로 변경하였습니다.

### 🖼 결과
- 화면 변화 없음