### PR TITLE
feat : 이미지 다운로드 기능 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "axios": "^1.3.4",
+        "downloadjs": "^1.4.7",
+        "html-to-image": "^1.11.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
@@ -22,6 +24,7 @@
         "recoil": "^0.7.6"
       },
       "devDependencies": {
+        "@types/downloadjs": "^1.4.3",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "eslint": "^8.34.0",
         "eslint-config-prettier": "^8.6.0",
@@ -3507,6 +3510,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/downloadjs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/downloadjs/-/downloadjs-1.4.3.tgz",
+      "integrity": "sha512-MjJepFle/tLtT2/jmDNth6ZnwWzEhm40L+olE5HKR70ISUCfgT55eqreeHldAzFLY2HDUGsn8zgyto8KygN0CA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
@@ -6287,6 +6296,11 @@
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
     },
+    "node_modules/downloadjs": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
+      "integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -8612,6 +8626,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "axios": "^1.3.4",
+    "downloadjs": "^1.4.7",
+    "html-to-image": "^1.11.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
@@ -42,6 +44,7 @@
     ]
   },
   "devDependencies": {
+    "@types/downloadjs": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "eslint": "^8.34.0",
     "eslint-config-prettier": "^8.6.0",

--- a/frontend/src/components/DownloadButton.tsx
+++ b/frontend/src/components/DownloadButton.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+import download from "downloadjs";
+import { toPng } from "html-to-image";
+
+interface Props {
+  previewRef: React.RefObject<HTMLDivElement>;
+}
+
+function DownloadButton({ previewRef }: Props) {
+  const handleClick = useCallback(async () => {
+    if (previewRef.current) {
+      download(await toPng(previewRef.current), "thumbnail.png");
+    }
+  }, [previewRef?.current]);
+
+  return (
+    <button
+      className="bg-primary-100 text-lighten text-md2 px-[20px] py-[10px] rounded-[100px] w-[335px]"
+      onClick={handleClick}
+    >
+      이미지 다운로드
+    </button>
+  );
+}
+
+export default DownloadButton;

--- a/frontend/src/features/App.tsx
+++ b/frontend/src/features/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useAppDispatch, useAppSelector } from "../app/hooks";
 import InteractiveContainer from "../components/InteractiveContainer";
 import BackgroundTool from "../sections/BackgroundTool";
@@ -8,24 +8,29 @@ import LayoutTool from "../sections/LayoutTool";
 import Preview from "../sections/Preview";
 import TextTool from "../sections/TextTool";
 import { helloWorld, selectHello } from "./appSlice";
+import DownloadButton from "../components/DownloadButton";
 
 const App = () => {
   const dispatch = useAppDispatch();
   const hello = useAppSelector(selectHello);
+  const previewRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     dispatch(helloWorld());
   }, []);
 
   return (
-    <InteractiveContainer>
+    <>
       <Header />
-      <Preview />
-      <BackgroundTool />
-      <LayoutTool />
-      <TextTool />
+      <InteractiveContainer>
+        <Preview previewRef={previewRef} />
+        <BackgroundTool />
+        <LayoutTool />
+        <TextTool />
+        <DownloadButton previewRef={previewRef} />
+      </InteractiveContainer>
       <Footer />
-    </InteractiveContainer>
+    </>
   );
 };
 

--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -1,7 +1,9 @@
-function Preview() {
-  return (
-    <div style={{ border: 'solid 1px blue', width: '375px' }}>Preview</div>
-  );
+interface Props {
+  previewRef: React.RefObject<HTMLDivElement>;
+}
+
+function Preview({ previewRef }: Props) {
+  return <div className="w-full border-solid border-2 border-indigo-600">Preview</div>;
 }
 
 export default Preview;


### PR DESCRIPTION
### ✅ PR 타입

- [x] Feature
- [ ] Bug Fix

### 📝 개요

DOM요소를 이미지로 저장하기

### 💽 작업 사항

DOM요소를 이미지로 저장하기 위해 [html-to-image](https://www.npmjs.com/package/html-to-image)와 [downloadjs](https://www.npmjs.com/package/downloadjs)를 사용하였습니다. 

### 🖼 결과

|     | before | after |
| --- | ------ | ------ |
|     |        | <img alt="result_screen" src="https://user-images.githubusercontent.com/76866137/221398762-db09ec8e-a955-471b-87e3-e32d2af2be49.png" />       |

### ✈ 기타(선택)

[참고 레퍼런스](https://betterprogramming.pub/heres-why-i-m-replacing-html2canvas-with-html-to-image-in-our-react-app-d8da0b85eadf)
