### PR TITLE
feat : 이미지 다운로드 기능 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
         "axios": "^1.3.4",
+        "html-to-image": "^1.11.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
@@ -23,6 +24,7 @@
       },
       "devDependencies": {
         "@iconify/react": "^4.1.0",
+        "@types/downloadjs": "^1.4.3",
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@typescript-eslint/parser": "^5.53.0",
         "eslint": "^8.34.0",
@@ -3529,6 +3531,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/downloadjs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/downloadjs/-/downloadjs-1.4.3.tgz",
+      "integrity": "sha512-MjJepFle/tLtT2/jmDNth6ZnwWzEhm40L+olE5HKR70ISUCfgT55eqreeHldAzFLY2HDUGsn8zgyto8KygN0CA==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.21.1",
@@ -8635,6 +8643,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA=="
     },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "axios": "^1.3.4",
+    "html-to-image": "^1.11.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "@iconify/react": "^4.1.0",
+    "@types/downloadjs": "^1.4.3",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
     "eslint": "^8.34.0",

--- a/frontend/src/components/DownloadButton.tsx
+++ b/frontend/src/components/DownloadButton.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+import download from 'downloadjs';
+import { toPng } from 'html-to-image';
+
+interface Props {
+  previewRef: React.RefObject<HTMLDivElement>;
+}
+
+function DownloadButton({ previewRef }: Props) {
+  const handleClick = useCallback(async () => {
+    if (previewRef.current) {
+      download(await toPng(previewRef.current), 'thumbnail.png');
+    }
+  }, [previewRef?.current]);
+
+  return (
+    <button
+      className="bg-primary-100 text-lighten text-md2 px-[20px] py-[10px] rounded-[100px] w-[335px]"
+      onClick={handleClick}
+    >
+      이미지 다운로드
+    </button>
+  );
+}
+
+export default DownloadButton;

--- a/frontend/src/features/App.tsx
+++ b/frontend/src/features/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import RatioTool from 'sections/RatioTool';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import InteractiveContainer from '../components/InteractiveContainer';
@@ -7,16 +7,20 @@ import Footer from '../sections/Footer';
 import Header from '../sections/Header';
 import Preview from '../sections/Preview';
 import TextTool from '../sections/TextTool';
+import DownloadButton from 'components/DownloadButton';
 
 const App = () => {
+  const previewRef = useRef<HTMLDivElement>(null);
+
   return (
     <>
       <Header />
       <InteractiveContainer>
-        <Preview />
+        <Preview previewRef={previewRef} />
         <RatioTool />
         <BackgroundTool />
         <TextTool />
+        <DownloadButton previewRef={previewRef} />
       </InteractiveContainer>
       <Footer />
     </>

--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState } from 'react';
 import { ratioAtom, previewImage, isImageBright } from 'atom';
 import { useRecoilValue } from 'recoil';
 
-export default function Preview() {
+interface Props {
+  previewRef: React.RefObject<HTMLDivElement>;
+}
+
+export default function Preview({ previewRef }: Props) {
   const imageSrc = useRecoilValue(previewImage);
   const isBright = useRecoilValue(isImageBright);
   const preview = useRef<HTMLDivElement>(null);


### PR DESCRIPTION
### ✅ PR 타입

- [x] Feature
- [ ] Bug Fix

### 📝 개요

DOM요소를 이미지로 저장하기

### 💽 작업 사항

DOM요소를 이미지로 저장하기 위해 [html-to-image](https://www.npmjs.com/package/html-to-image)와 [downloadjs](https://www.npmjs.com/package/downloadjs)를 사용하였습니다. 

### 🖼 결과

|     | before | after |
| --- | ------ | ------ |
|     |        | <img alt="result_screen" src="https://user-images.githubusercontent.com/76866137/221398762-db09ec8e-a955-471b-87e3-e32d2af2be49.png" />       |

### ✈ 기타(선택)

[참고 레퍼런스](https://betterprogramming.pub/heres-why-i-m-replacing-html2canvas-with-html-to-image-in-our-react-app-d8da0b85eadf)
