### PR TITLE
Header와 Preview 화면 위치 유지

### DIFF
--- a/frontend/src/components/TextPreview.tsx
+++ b/frontend/src/components/TextPreview.tsx
@@ -20,7 +20,7 @@ const TextPreview = () => {
   };
 
   return (
-    <div className={styles.container}>
+    <div style={{ position: 'relative', zIndex: 98 }} className={styles.container}>
       <div className={styles.pos}>
         {cnt > 0 && (
           <span className={styles.first} style={{ color: getRGB(first.fontColor) }}>

--- a/frontend/src/sections/Header.tsx
+++ b/frontend/src/sections/Header.tsx
@@ -14,7 +14,10 @@ function Header() {
   };
 
   return (
-    <div className="w-full flex-center bg-surface drop-shadow-md py-[12px]">
+    <div
+      style={{ position: 'sticky', top: 0, zIndex: 99, boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.05)' }}
+      className="w-full flex-center bg-surface py-[12px]"
+    >
       <div className="w-11/12 flex flex-row justify-between sm:w-[640px] md:w-[768px] lg:w-1024">
         <button
           className="w-[100px] text-left disabled:opacity-50 hover:font-bold"

--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -19,28 +19,53 @@ export default function Preview({ previewRef }: Props) {
   useEffect(() => {
     if (preview && preview.current) {
       setPreviewWidth(preview.current.clientHeight * previewRatio);
-    } else {
-      setPreviewWidth(previewWidth);
     }
   }, [previewRatio]);
 
   return (
     <>
-      <div className="w-full h-[188px] tablet:h-[300px] flex justify-center items-center" ref={previewRef}>
-        <div
-          ref={preview}
-          style={{
-            width: `${previewWidth}px`,
-            height: '100%',
-            backgroundImage: `url(${imageSrc})`,
-            backgroundSize: 'auto 100%',
-            backgroundRepeat: 'no-repeat',
-            backgroundPosition: 'center',
-            filter: `${isBright ? 'brightness(100%)' : 'brightness(70%)'}`,
-          }}
-        >
-          <TextPreview />
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          position: 'sticky',
+          background: 'white',
+          top: '48px',
+          zIndex: 97,
+        }}
+      >
+        <div className="w-full h-[188px] tablet:h-[300px] flex justify-center items-center" ref={previewRef}>
+          <div
+            ref={preview}
+            style={{
+              width: `${previewWidth}px`,
+              height: '100%',
+              backgroundImage: `url(${imageSrc})`,
+              backgroundSize: 'auto 100%',
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'center',
+            }}
+          >
+            <TextPreview />
+            <div
+              style={{
+                position: 'relative',
+                bottom: '100%',
+                zIndex: 97,
+                width: `${previewWidth}px`,
+                height: '100%',
+                background: `${isBright ? 'transparent' : 'rgba(0, 0, 0, 0.3)'}`,
+              }}
+            ></div>
+          </div>
         </div>
+        <div
+          style={{
+            width: '100%',
+            height: '16px',
+            background: 'white',
+          }}
+        ></div>
       </div>
     </>
   );


### PR DESCRIPTION
### ✅ PR 타입

- [x] Feature
- [ ] Bug Fix

### 📝 개요
Header와 Preview의 화면 위치를 고정하였습니다.

### 💽 작업 사항
- position속성의 sticky를 이용하여 Header와 Preview가 스크롤이 내려가더라도 화면상의 위치를 유지하도록 하였습니다.
- dimmed처리에서 Preview의 글자까지 어두워지는 부분을 글자는 어두워지지않도록 수정하였습니다.

### 🖼 결과
- before

https://user-images.githubusercontent.com/75886763/221415216-f71b7c38-6ea2-4f4b-91b9-74df494850fe.mov

- after

https://user-images.githubusercontent.com/75886763/221415278-0372351b-51b8-4b40-8eaa-aed26de54b42.mov
