### PR TITLE
썸네일 텍스트 폰트 굵기 수정

### DIFF
--- a/frontend/src/components/TextPreview.tsx
+++ b/frontend/src/components/TextPreview.tsx
@@ -12,7 +12,7 @@ const TextPreview = () => {
   const third = useRecoilValue(textsAll(2));
 
   const styles = {
-    container: `w-full h-full grid grid-cols-1 place-content-cneter p-5 overflow-hidden`,
+    container: `w-full h-full grid grid-cols-1 place-content-cneter p-5 overflow-hidden font-bold`,
     pos: `flex flex-col ${pos.justifyContent} ${pos.alignItems}`,
     sub: `flex flex-col w-full ${pos.justifyContent} ${pos.subAlignItems} `,
     first: `break-all ${first.fontColor} ${first.fontSize}`,


### PR DESCRIPTION
### ✅ PR 타입

- [ ] Feature
- [x] Bug Fix

### 📝 개요

썸네일의 SUIT 폰트의 굵기가 가는 현상 수정
<img width="254" alt="image" src="https://user-images.githubusercontent.com/92029332/221456024-7de237d6-1351-4504-99aa-0031b7d46e93.png">


### 💽 작업 사항

썸네일의 font-weight 700으로 수정

### 🖼 결과

before
<img width="375" alt="image" src="https://user-images.githubusercontent.com/92029332/221456147-ebc9dfa5-a02b-4421-b675-dcda8f27b00c.png">

after
<img width="434" alt="image" src="https://user-images.githubusercontent.com/92029332/221456089-9478121f-363f-4777-98f3-f45a35efba5b.png">
 


