### PR TITLE
fix : 드롭다운 타이틀 폰트수정 안되는 현상 수정

### DIFF
--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -12,6 +12,7 @@ interface Props<T> {
 function Dropdown<T extends string>({ defaultValue: value, list, handleChange, styleList }: Props<T>) {
   const [isOpen, setIsOpen] = useState(false);
   const [title, setTitle] = useState(list[value ?? 0]);
+  const [titleStyle, setTitleStyle] = useState(styleList ? styleList[value ?? 0] : '');
   const [dropdownList, setDropdownList] = useState(
     list.map((elem, idx) => {
       return { content: elem, checked: idx === value ?? 0 ? true : false };
@@ -20,6 +21,7 @@ function Dropdown<T extends string>({ defaultValue: value, list, handleChange, s
 
   const handleLabelClose = (e: MouseEvent<HTMLLIElement>) => {
     const selectedContent = e.currentTarget.dataset.content as T;
+    const selectedStyle = e.currentTarget.dataset.style as string;
     setIsOpen(false);
     setDropdownList(
       dropdownList.map((elem) => {
@@ -28,6 +30,7 @@ function Dropdown<T extends string>({ defaultValue: value, list, handleChange, s
     );
     setTitle(selectedContent);
     handleChange(selectedContent);
+    setTitleStyle(selectedStyle);
   };
 
   return (
@@ -36,7 +39,7 @@ function Dropdown<T extends string>({ defaultValue: value, list, handleChange, s
         className="flex justify-between items-center px-4 border-1 border-black rounded-md h-11 text-sm"
         onClick={() => setIsOpen((prev) => !prev)}
       >
-        <div>{title}</div>
+        <div className={titleStyle}>{title}</div>
         <IoIosArrowDown />
       </div>
       {isOpen && (
@@ -47,6 +50,7 @@ function Dropdown<T extends string>({ defaultValue: value, list, handleChange, s
                 className={`flex justify-between ${styleList && styleList[idx]}`}
                 key={option.content}
                 data-content={option.content}
+                data-style={styleList ? styleList[idx] : ''}
                 onClick={handleLabelClose}
               >
                 <span>{option.content}</span>


### PR DESCRIPTION
### ✅ PR 타입

- [x] Feature
- [ ] Bug Fix

### 📝 개요

드롭다운에서 설정되는 폰트를 확인할 수 있어요

### 💽 작업 사항

작업 내용을 적어주세요

### 🖼 결과

<img width="474" alt="image" src="https://user-images.githubusercontent.com/92029332/221528485-c63e1853-028e-4d90-b988-f9674aa33b95.png">

