### PR TITLE
fix: download image not rounded

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       working-directory: ./frontend
     steps:

--- a/frontend/src/sections/Preview.tsx
+++ b/frontend/src/sections/Preview.tsx
@@ -48,31 +48,32 @@ export default function Preview({ previewRef }: Props) {
         }}
       >
         <div className="w-full h-[200px] tablet:h-[320px] flex justify-center items-center" ref={preview}>
-          <div
-            ref={previewRef}
-            style={{
-              width: `${previewWidth}px`,
-              height: '100%',
-              backgroundColor: `${tab === '1' ? currentColor.color : '#F0F0F0'}`,
-              backgroundImage:
-                tab !== '1' ? `url(${imageSrc})` : colorTab === '2' ? `${currentGradation.color}` : 'none',
-              backgroundSize: 'cover',
-              backgroundRepeat: 'no-repeat',
-              backgroundPosition: 'center',
-              borderRadius: '5px',
-            }}
-          >
-            <TextPreview />
+          <div className="rounded-[5px] h-full overflow-hidden">
             <div
+              ref={previewRef}
               style={{
-                position: 'relative',
-                bottom: '100%',
-                zIndex: 97,
                 width: `${previewWidth}px`,
                 height: '100%',
-                background: `${isBright || tab === '1' ? 'transparent' : 'rgba(0, 0, 0, 0.3)'}`,
+                backgroundColor: `${tab === '1' ? currentColor.color : '#F0F0F0'}`,
+                backgroundImage:
+                  tab !== '1' ? `url(${imageSrc})` : colorTab === '2' ? `${currentGradation.color}` : 'none',
+                backgroundSize: 'cover',
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'center',
               }}
-            ></div>
+            >
+              <TextPreview />
+              <div
+                style={{
+                  position: 'relative',
+                  bottom: '100%',
+                  zIndex: 97,
+                  width: `${previewWidth}px`,
+                  height: '100%',
+                  background: `${isBright || tab === '1' ? 'transparent' : 'rgba(0, 0, 0, 0.3)'}`,
+                }}
+              ></div>
+            </div>
           </div>
         </div>
         <div


### PR DESCRIPTION
### ✅ PR 타입

- [ ] Feature
- [x] Bug Fix

### 📝 개요

- 다운로드한 이미지 모서리가 둥근 버그를 수정하였습니다.

### 💽 작업 사항

- rounded 스타일을 미리보기 요소 상위에 적용하였습니다.

### 🖼 결과

|     | before | after |
| --- | ------ | ----- |
|     | ![thumbnail 32](https://github.com/Yangjaecheon-Otter-Guardians/simple-thumbnail/assets/66757141/b81a092d-5b75-4520-93c8-a20eaa42e79f) | ![thumbnail](https://github.com/Yangjaecheon-Otter-Guardians/simple-thumbnail/assets/66757141/ca08ed55-afc9-4e64-9094-b48f514aad19) |

### ✈ 기타(선택)

- #129 
